### PR TITLE
Improvements

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -100,7 +100,7 @@
   </div>
 
 
-  <header class="w3-container w3-black w3-top" style="z-index:99">
+  <header class="w3-container w3-black w3-top">
     <div class="w3-dropdown-hover">
       <a href="/kotlin/index">
         <i class="fa fa-bars w3-xxlarge w3-button w3-black"></i>
@@ -140,7 +140,7 @@
     </div>
   </section>
 
-  <footer class="w3-container w3-black w3-bottom" style="z-index:99">
+  <footer class="w3-container w3-black w3-bottom">
       &copy; André L. Santos,&nbsp;<a href="{{site.url}}/kotlin">{{site.data.capitulos.titulo}}</a>
       <a href="http://www.iscte-iul.pt" target="_blank"><img src="/iscte.png" height="40px" class="w3-display-right"/></a>
   </footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 
 
   <script>
+    /* Disable to prevent error on selecting text
     document.addEventListener('selectionchange', () => {
 
       var sel = document.getSelection().toString()
@@ -32,6 +33,7 @@
         document.getElementById('question').style.visibility = 'hidden'
       //window.alert(document.getSelection().anchorNode.data);
     });
+    */
 
     function copy(id) {
       /* Get the text field */

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -130,7 +130,7 @@
 
 
 
-  <section>
+  <main>
     <div class="w3-container w3-padding-64">
       {% if page.image != null %}
       <img src="{{ page.image }}" />
@@ -138,7 +138,7 @@
       {{ content }}
       <br>
     </div>
-  </section>
+  </main>
 
   <footer class="w3-container w3-black w3-bottom">
       &copy; André L. Santos,&nbsp;<a href="{{site.url}}/kotlin">{{site.data.capitulos.titulo}}</a>

--- a/style.css
+++ b/style.css
@@ -8,6 +8,15 @@ header .w3-dropdown-hover {
   margin-right: 0.2em;
 }
 
+main {
+  display: flex;
+  justify-content: center;
+}
+
+main > div {
+  max-width: 960px;
+}
+
 footer {
   display: flex;
   align-items: center;
@@ -18,11 +27,6 @@ footer {
 footer,
 header {
   z-index: 10;
-}
-
-div {
-  max-width: 960px;
-  text-align: justify;
 }
 
 .w3-panel,

--- a/style.css
+++ b/style.css
@@ -15,6 +15,11 @@ footer {
   padding: 10px;
 }
 
+footer,
+header {
+  z-index: 10;
+}
+
 div {
   max-width: 960px;
   text-align: justify;

--- a/style.css
+++ b/style.css
@@ -20,21 +20,9 @@ div {
   text-align: justify;
 }
 
-div .w3-panel {
-  margin-left: 20px;
-  margin-right: 20px;
-}
-
-p {
-  margin-left: 20px;
-  margin-right: 20px;
-}
-
-h2 {
-  margin-left: 20px;
-  margin-right: 20px;
-}
-
+.w3-panel,
+p,
+h2,
 h3 {
   margin-left: 20px;
   margin-right: 20px;


### PR DESCRIPTION
This is best to be reviewed commit by commit

These changes address the following points in order:
- Refactoring styles
   - Selectors with the same rules can be joined using `,`
- Remove inline styles
  - It is best to use css selectors when possible, instead of inline styles, so the z-index rules are now targeting `footer` and `header`
- Center and remove justified text
  - Web pages aligned to the left are very early 2000s. Using `display: flex` and `justify-content: center` brings it to the 2010s;
  - To prevent word spacing variation, text is no longer justified. Here's an article explaining what I'm complaining about https://practicaltypography.com/justified-text.html
- Prevent error on text selection
  - Anytime the user selects text, an error is logged. I commented the legacy code that caused it.

I'm having trouble building this on my machine, so please test this before merging.
